### PR TITLE
Add JUnit 5 dependency and JaCoCo plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
             <version>${flyway.version}</version>
         </dependency>
 
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.11.3</version>
+			<scope>test</scope>
+		</dependency>
+
 
 	</dependencies>
 	<build>
@@ -84,6 +91,25 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/test/java/edu/harvard/iq/dataverse_hub/InstallationGitImporterTests.java
+++ b/src/test/java/edu/harvard/iq/dataverse_hub/InstallationGitImporterTests.java
@@ -1,0 +1,69 @@
+package edu.harvard.iq.dataverse_hub;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import edu.harvard.iq.dataverse_hub.controller.scheduled.InstallationGitImporter;
+import edu.harvard.iq.dataverse_hub.model.Installation;
+import edu.harvard.iq.dataverse_hub.service.ScheduledJobService;
+
+@SpringBootTest
+public class InstallationGitImporterTests {
+
+    @Autowired
+    InstallationGitImporter installationGitImporter;
+
+    @Autowired 
+    ScheduledJobService scheduledJobService;
+
+    @Test
+    public void testImportInstallation() {
+
+        Boolean isDue = scheduledJobService.isDue(installationGitImporter.getClass().getSimpleName());
+        assertNotEquals(isDue, null);
+        List<Installation> installations = installationGitImporter.runTask();
+        if(isDue){
+            assertNotEquals(installations, null);
+        } else {
+            assertEquals(installations, null);
+        }
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            InstallationGitImporter.transform(null);
+        });
+
+        InstallationGitImporter.InstallationWrapper installationWrapper = new InstallationGitImporter.InstallationWrapper();
+        installationWrapper.setName("Test Installation");
+        installationWrapper.setUrl("https://example.com");
+        installationWrapper.setDataverseVersion("6.0");
+        installationWrapper.setLatitude(2.0);
+        installationWrapper.setLongitude(2.0);
+        installationWrapper.setClientInstitutionId("CI-123");
+        installationWrapper.setContinent("NA");
+        installationWrapper.setCountry("US");
+        installationWrapper.setAdditionalContactInformation("646-123-4567");
+        installationWrapper.setNotes("notes");
+        installationWrapper.setDescription("description");
+        installationWrapper.setHostname("hostname");
+        installationWrapper.setLaunchYear(1985);
+        installationWrapper.setDoiAuthority("DOIAUTH");
+        installationWrapper.setGdccMember(false);
+        installationWrapper.setContactEmail("email@email.com");
+        Installation installationDTO = InstallationGitImporter.transform(installationWrapper);
+        
+        assertNotEquals(installationDTO, null);
+
+       
+       
+      
+       
+    }
+
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the `InstallationGitImporter` class, updates the `pom.xml` file to include new dependencies and plugins, and adds new unit tests. The changes enhance functionality, improve test coverage, and ensure better code maintainability.

### Enhancements to `InstallationGitImporter`:

* Modified the `runTask` method to return a list of `Installation` objects instead of void, ensuring the method now returns meaningful data. (`src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/InstallationGitImporter.java`)
* Updated the `importInstallations` method to return a list of `Installation` objects and handle potential null values appropriately. (`src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/InstallationGitImporter.java`)
* Changed the visibility of `GitHubInstallationWrapper` and `InstallationWrapper` classes from private to public, allowing them to be accessed outside the class. (`src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/InstallationGitImporter.java`)
* Added setter methods to the `InstallationWrapper` class to facilitate easier manipulation of its properties. (`src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/InstallationGitImporter.java`)

### Dependency and Plugin Updates:

* Added `junit-jupiter` dependency to the `pom.xml` file to enable JUnit 5 testing. (`pom.xml`)
* Included the `jacoco-maven-plugin` in the `pom.xml` file for code coverage reporting. (`pom.xml`)

### New Unit Tests:

* Introduced a new test class `InstallationGitImporterTests` to verify the functionality of `InstallationGitImporter`, including tests for null checks and proper transformation of `InstallationWrapper` objects. (`src/test/java/edu/harvard/iq/dataverse_hub/InstallationGitImporterTests.java`)