### PR TITLE
Add endpoint to retrieve Dataverse installations by country

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/InstallationController.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/InstallationController.java
@@ -6,9 +6,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import edu.harvard.iq.dataverse_hub.controller.api.annotations.InstallationControllerDocs;
+import edu.harvard.iq.dataverse_hub.controller.api.payloadBeans.InstallationsByCountry;
 import edu.harvard.iq.dataverse_hub.model.Installation;
 import edu.harvard.iq.dataverse_hub.model.InstallationVersionInfo;
 import edu.harvard.iq.dataverse_hub.service.InstallationService;
+
 import java.util.List;
 import org.springframework.web.bind.annotation.PutMapping;
 
@@ -35,6 +37,12 @@ public class InstallationController {
     @InstallationControllerDocs.GetInstallationsStatus
     public List<InstallationVersionInfo> geInstallationsStatus(){
         return installationService.getInstallationInfo();
+    }
+
+    @GetMapping("country")
+    @InstallationControllerDocs.getInstallationsByCountry
+    public List<InstallationsByCountry> getInstallationsByCountry(){
+        return installationService.getInstallationsByCountry();
     }
 
 

--- a/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/annotations/InstallationControllerDocs.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/annotations/InstallationControllerDocs.java
@@ -98,4 +98,29 @@ public @interface InstallationControllerDocs {
             description = "Returns a list of the most recent status of all registered Dataverse installations")
     public @interface GetInstallationsStatus {}
 
+    @Target({ElementType.METHOD})    
+    @Retention(RetentionPolicy.RUNTIME)
+    @Tag(name = "Installation by country list", 
+            description = "Rregistered dataverse installations by each country")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", 
+                        description = "Installation by country count success",
+                        content = @Content(mediaType = "application/json",
+                        schema = @Schema(implementation = Installation.class),
+                        examples = @ExampleObject(APIPayloadSamples.INSTALLATION_ARRAY))),
+        @ApiResponse(responseCode = "400", 
+                        description = "Bad Request on Installation by country count list",
+                        content = @Content(mediaType = "application/json",
+                        schema = @Schema(implementation = ServerMessageResponse.class),
+                        examples = @ExampleObject(APIPayloadSamples.SERVER_RESPONSE_400))),
+        @ApiResponse(responseCode = "500", 
+                        description = "Internal Server Error on Installation by country count",
+                        content = @Content(mediaType = "application/json",
+                        schema = @Schema(implementation = ServerMessageResponse.class),
+                        examples = @ExampleObject(APIPayloadSamples.SERVER_RESPONSE_500)))
+    })
+    @Operation(summary = "Get a count of the installations by country", 
+                description = "Returns a count of the number of registered Dataverse installations by country")
+    public @interface getInstallationsByCountry {}
+
 }

--- a/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/payloadBeans/InstallationsByCountry.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/payloadBeans/InstallationsByCountry.java
@@ -1,0 +1,52 @@
+package edu.harvard.iq.dataverse_hub.controller.api.payloadBeans;
+
+import java.util.Date;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "A representation of the number of Dataverse installations by country")
+public class InstallationsByCountry {
+
+    @Schema(description = "Country of the Dataverse installation",
+            example = "United States")
+    private String country;
+    @Schema(description = "Number of Dataverse installations in the country",
+            example = "3")
+    private Long count;
+    @Schema(description = "Date when the information was captured",
+            example = "2024-10-31T20:13:03.422+00:00")
+    private Date captureDate;
+
+    public InstallationsByCountry(String country, Long count) {
+        this.country = country;
+        this.count = count;
+        this.captureDate = new Date();
+    }
+
+    public String getCountry() {
+        return this.country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public Long getCount() {
+        return this.count;
+    }
+
+    public void setCount(Long count) {
+        this.count = count;
+    }
+
+    public Date getCaptureDate() {
+        return this.captureDate;
+    }
+
+    public void setCaptureDate(Date captureDate) {
+        this.captureDate = captureDate;
+    }
+
+
+
+}

--- a/src/main/java/edu/harvard/iq/dataverse_hub/repository/InstallationRepo.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/repository/InstallationRepo.java
@@ -1,7 +1,11 @@
 package edu.harvard.iq.dataverse_hub.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import edu.harvard.iq.dataverse_hub.controller.api.payloadBeans.InstallationsByCountry;
 import edu.harvard.iq.dataverse_hub.model.Installation;
 
 
@@ -9,5 +13,15 @@ public interface InstallationRepo extends JpaRepository<Installation, String> {
     
     @Query("SELECT i FROM Installation i WHERE i.dvHubId = ?1")
     Installation findByDVHubId(String dvHubId);
+
+    @Query("""
+            SELECT NEW edu.harvard.iq.dataverse_hub.controller.api.payloadBeans.InstallationsByCountry(
+                i.country, 
+                COUNT(i)) 
+            FROM Installation i 
+            GROUP BY i.country
+            ORDER BY COUNT(i) DESC
+            """)
+    List<InstallationsByCountry> getInstallationsByCountry();
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse_hub/service/InstallationService.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/service/InstallationService.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse_hub.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import edu.harvard.iq.dataverse_hub.controller.api.payloadBeans.InstallationsByCountry;
 import edu.harvard.iq.dataverse_hub.controller.scheduled.VersionDVInstallationCheck;
 import edu.harvard.iq.dataverse_hub.model.Installation;
 import edu.harvard.iq.dataverse_hub.model.InstallationVersionInfo;
@@ -65,6 +66,10 @@ public class InstallationService {
         }
         
         return installationVersionInfoRepo.save(vi);
+    }
+
+    public List<InstallationsByCountry> getInstallationsByCountry(){
+        return installationRepo.getInstallationsByCountry();
     }
 
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the count of Dataverse installations by country. The main changes include the addition of a new API endpoint, corresponding documentation, and a new data class to represent the response.

### New Feature: Installations by Country

* **API Endpoint Addition:**
  * [`src/main/java/edu/harvard/iq/dataverse_hub/controller/api/InstallationController.java`](diffhunk://#diff-c5ba6860e07956d13ebebdff970b6218f4b5f7c23ddb61facf5cdc425b60c00eR42-R47): Added a new `getInstallationsByCountry` method to handle GET requests and return the count of installations by country.
  * [`src/main/java/edu/harvard/iq/dataverse_hub/controller/api/annotations/InstallationControllerDocs.java`](diffhunk://#diff-4c57cb9db15f16e9eacdb54c00e8fa2c5563e96ab672a3056e9810bcf4669ef8R101-R125): Added a new annotation `@getInstallationsByCountry` for documenting the new API endpoint.

* **Data Representation:**
  * [`src/main/java/edu/harvard/iq/dataverse_hub/controller/api/payloadBeans/InstallationsByCountry.java`](diffhunk://#diff-c773fd0b73197a8e846daef5a4c767da9ffef259c8d81ffe7ed44c38f03a3e4bR1-R52): Introduced a new class `InstallationsByCountry` to represent the number of Dataverse installations by country.

* **Repository Query:**
  * [`src/main/java/edu/harvard/iq/dataverse_hub/repository/InstallationRepo.java`](diffhunk://#diff-2a0789bc3b383640e93e95628d2db132028ce128b78193e810a346f1a0314760R17-R26): Added a new query method `getInstallationsByCountry` to fetch the count of installations grouped by country.

* **Service Layer:**
  * [`src/main/java/edu/harvard/iq/dataverse_hub/service/InstallationService.java`](diffhunk://#diff-6fb9f15a96e096fbe0b2d193c6e2eb185583aadc1e84dc0fcf86f19692769bdfR71-R74): Added a new service method `getInstallationsByCountry` to call the repository method and return the data.