### PR TITLE
Historic metrics importer

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse_hub/model/ScheduledJob.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/model/ScheduledJob.java
@@ -21,6 +21,7 @@ public class ScheduledJob {
     private String description;
     private String jobName;
     private Integer frequency;
+    private Boolean recurring;
 
     public Integer getJobId() {
         return this.jobId;
@@ -54,6 +55,14 @@ public class ScheduledJob {
         this.frequency = frequency;
     }
 
+    public Boolean getRecurring() {
+        return this.recurring;
+    }
+
+    public void setRecurring(Boolean recurring) {
+        this.recurring = recurring;
+    }
+
     @Override
     public String toString() {
         return "{" +
@@ -61,6 +70,7 @@ public class ScheduledJob {
             ", description='" + getDescription() + "'" +
             ", jobName='" + getJobName() + "'" +
             ", frequency='" + getFrequency() + "'" +
+            ", recurring='" + getRecurring() + "'"+
             "}";
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse_hub/service/ScheduledJobService.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/service/ScheduledJobService.java
@@ -20,7 +20,7 @@ public class ScheduledJobService {
     @Autowired
     private ScheduledJobTransactionLogRepo scheduledJobTransactionLogRepo;
 
-    private final static int DEFAULT_FREQUENCY = 3600000;
+    private final static int DEFAULT_FREQUENCY = 86400000;
 
     public ScheduledJob save(ScheduledJob scheduledJob) {
         return scheduledJobRepo.save(scheduledJob);
@@ -52,7 +52,10 @@ public class ScheduledJobService {
             jobConfig.setJobName(jobName);
             jobConfig.setDescription(jobName);
             jobConfig.setFrequency(DEFAULT_FREQUENCY);
+            jobConfig.setRecurring(true);
             scheduledJobRepo.save(jobConfig);
+        } else if (!jobConfig.getRecurring()) {
+            return false;
         }
         ScheduledJobTransactionLog lastTransaction =
             scheduledJobTransactionLogRepo.findLatestTransactionByJobId(
@@ -70,6 +73,15 @@ public class ScheduledJobService {
         }
 
         return false;
+    }
+
+    public ScheduledJob disableRecurrence(String jobName) {
+        ScheduledJob jobConfig = scheduledJobRepo.findByName(jobName);
+        if(jobConfig != null){
+            jobConfig.setRecurring(false);
+            scheduledJobRepo.save(jobConfig);
+        }
+        return jobConfig;
     }
 
     public ScheduledJobTransactionLog saveTransactionLog(ScheduledJob job, Integer status) {

--- a/src/main/resources/db/migration/V1_0_0__initial_load.sql
+++ b/src/main/resources/db/migration/V1_0_0__initial_load.sql
@@ -57,7 +57,8 @@ CREATE TABLE IF NOT EXISTS scheduled_job (
   job_id integer NOT NULL PRIMARY KEY,
   description varchar,
   job_name varchar,
-  frequency integer
+  frequency integer,
+  recurring boolean DEFAULT true
 );
 
 CREATE TABLE IF NOT EXISTS scheduled_job_transaction_log (
@@ -81,6 +82,7 @@ CREATE TABLE IF NOT EXISTS installation_version_info (
 INSERT INTO access_token (token_id, user_id) VALUES ('257d4485-173f-4a6d-913d-ee20c9d7bc06', 0);
 
 INSERT INTO scheduled_job (job_id, description, job_name, frequency) VALUES (nextval('scheduled_job_seq'), 'Installation importer', 'InstallationGitImporter', 86400000);
+INSERT INTO scheduled_job (job_id, description, job_name, frequency) VALUES (nextval('scheduled_job_seq'), 'Monthly Metrics importer', 'InstallationMetricsMonthlyImporter', 86400000);
 INSERT INTO scheduled_job (job_id, description, job_name, frequency) VALUES (nextval('scheduled_job_seq'), 'Version Status check', 'VersionDVInstallationCheck', 43200000);
 INSERT INTO scheduled_job (job_id, description, job_name, frequency) VALUES (nextval('scheduled_job_seq'), 'Installation Metrics Import', 'InstallationMetricsImporter', 86400000);
 INSERT INTO scheduled_job (job_id, description, job_name, frequency) VALUES (nextval('scheduled_job_seq'), 'Dev Metrics importer', 'DevMetricsImporter', 43200000);


### PR DESCRIPTION
This pull request introduces a new scheduled job for importing monthly installation metrics and adds support for recurring jobs. It also includes changes to the database schema and updates to existing classes to accommodate these new features.

### New Scheduled Job for Monthly Installation Metrics:

* [`src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/InstallationMetricsMonthlyImporter.java`](diffhunk://#diff-35dfd2212e31e7675d3d12c591ed5a8bfddd19026378a1b93c71e826213309edR1-R214): Created a new class `InstallationMetricsMonthlyImporter` to import monthly installation metrics. This class includes methods for running the task, starting the task, importing installation metrics, and retrieving metrics.

### Support for Recurring Jobs:

* [`src/main/java/edu/harvard/iq/dataverse_hub/model/ScheduledJob.java`](diffhunk://#diff-bf2a4ea19345a84be1d731bf3cec3a7de62ec8d221cf6804687730cc57929187R24): Added a new field `recurring` to the `ScheduledJob` class, along with its getter and setter methods. Updated the `toString` method to include the `recurring` field. [[1]](diffhunk://#diff-bf2a4ea19345a84be1d731bf3cec3a7de62ec8d221cf6804687730cc57929187R24) [[2]](diffhunk://#diff-bf2a4ea19345a84be1d731bf3cec3a7de62ec8d221cf6804687730cc57929187R58-R73)
* [`src/main/java/edu/harvard/iq/dataverse_hub/service/ScheduledJobService.java`](diffhunk://#diff-b804fcddf5a7676664bf767ea8e2649ccce5a4a6cb9df5cb81629e9a922367b1R55-R58): Updated the `isDue` method to check for the `recurring` field and added a new method `disableRecurrence` to disable the recurrence of a job. [[1]](diffhunk://#diff-b804fcddf5a7676664bf767ea8e2649ccce5a4a6cb9df5cb81629e9a922367b1R55-R58) [[2]](diffhunk://#diff-b804fcddf5a7676664bf767ea8e2649ccce5a4a6cb9df5cb81629e9a922367b1R78-R86)

### Database Schema Changes:

* [`src/main/resources/db/migration/V1_0_0__initial_load.sql`](diffhunk://#diff-7869015f3e273c1711fd603a8813ca7d8fd69b37b63b9a39387ebe02a5e84b5fL60-R61): Modified the `scheduled_job` table to include a new column `recurring` with a default value of `true`. Added an entry for the new `InstallationMetricsMonthlyImporter` job. [[1]](diffhunk://#diff-7869015f3e273c1711fd603a8813ca7d8fd69b37b63b9a39387ebe02a5e84b5fL60-R61) [[2]](diffhunk://#diff-7869015f3e273c1711fd603a8813ca7d8fd69b37b63b9a39387ebe02a5e84b5fR85)

### Minor Changes:

* [`src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/InstallationMetricsImporter.java`](diffhunk://#diff-6314da169748040bdadfb8170f29561575af99f8da61c3258154a48056260fd5R27-R35): Moved the `PROTOCOL` field to improve code organization.
* [`src/main/java/edu/harvard/iq/dataverse_hub/service/ScheduledJobService.java`](diffhunk://#diff-b804fcddf5a7676664bf767ea8e2649ccce5a4a6cb9df5cb81629e9a922367b1L23-R23): Changed the `DEFAULT_FREQUENCY` value to `86400000` (24 hours).