### PR TITLE
Cache fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/InstallationController.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/controller/api/InstallationController.java
@@ -3,8 +3,6 @@ package edu.harvard.iq.dataverse_hub.controller.api;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,7 +12,6 @@ import edu.harvard.iq.dataverse_hub.controller.api.request.InstallationFilterPar
 import edu.harvard.iq.dataverse_hub.controller.api.request.InstallationFilterParamsMonthly;
 import edu.harvard.iq.dataverse_hub.controller.api.response.InstallationsByCountry;
 import edu.harvard.iq.dataverse_hub.model.Installation;
-import edu.harvard.iq.dataverse_hub.model.InstallationMetrics;
 import edu.harvard.iq.dataverse_hub.model.InstallationVersionInfo;
 import edu.harvard.iq.dataverse_hub.model.DTO.InstallationDTO;
 import edu.harvard.iq.dataverse_hub.model.DTO.MetricsByInstallationDTO;

--- a/src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/VersionDVInstallationCheck.java
+++ b/src/main/java/edu/harvard/iq/dataverse_hub/controller/scheduled/VersionDVInstallationCheck.java
@@ -8,7 +8,6 @@ import javax.cache.CacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -36,14 +35,14 @@ public class VersionDVInstallationCheck {
     private RestUtilService restUtilService;
 
     @Autowired
-    CacheManager cacheManager;
+    private CacheManager cacheManager;
 
     private final String JOB_NAME = this.getClass().getSimpleName();
     private final String PROTOCOL = "https://";
     private final String ENDPOINT = "/api/info/version";
 
 
-    @Scheduled(fixedRate = 10000)
+    @Scheduled(fixedRate = 3600000)
     public List<InstallationVersionInfo> runTask(){
         logger.info("Starting {} job", JOB_NAME);
 
@@ -57,10 +56,6 @@ public class VersionDVInstallationCheck {
         }
     }
 
-    /**
-     * @param isDue
-     * @return
-     */
     public List<InstallationVersionInfo> startTask(Boolean isDue) throws JsonProcessingException {
 
         if(isDue == null){
@@ -70,7 +65,7 @@ public class VersionDVInstallationCheck {
         return isDue ? importInstallationsStatus(null) : null;
     }
 
-    
+ 
     public List<InstallationVersionInfo> importInstallationsStatus(List<Installation> dvInstallationsList) {
         
         List<InstallationVersionInfo> versionInfoList = null;
@@ -95,6 +90,7 @@ public class VersionDVInstallationCheck {
             installationService.saveAllVersionInfo(versionInfoList);
             scheduledJobService.saveTransactionLog(JOB_NAME, 1);
             clearCache();
+            installationService.getInstallationInfo();
         } catch (Exception e) {
             scheduledJobService.saveTransactionLog(JOB_NAME, -1);
         }


### PR DESCRIPTION
While working with @g-saracca to deploy the hub metrics into the SPA he reported a couple of issues that are solved with this PR.


- It was identified that when the response was cached between two endpoints " /metrics" and "/monthly" was being shared, this happened since the "/metrics" is using under the hood the same service but there was no key on the cache to distinguish them, making the same response no matter what endpoint would be called. To fix it we added a hash code generated from the search parameters and created a key to save the cache.

- It also was identified that the response of the endpoint could be cached briefly before the execution of the importer, leaving an outdated copy in memory, to solve this the importers now will clear all the cache.
