### PR TITLE
Add developer guide with database dump instructions

### DIFF
--- a/docs/Sphinx-guides/source/developerGuide/databaseDump.md
+++ b/docs/Sphinx-guides/source/developerGuide/databaseDump.md
@@ -1,0 +1,40 @@
+# Database dump
+
+For development or testing sometimes we need to have an accurate representation of the data that we have on an environment, here are a list of steps to follow to get this working:
+
+## Generate a database dump
+
+The first step is to generate this file, if you already have this you can jump to the next step.
+
+The first step is to stablish a connection trough ssh for example:
+
+```
+ssh -i ./mykey.key rocky@127.0.0.1
+```
+
+Once that we are connected we can generate the image with(replace `very$4f3Pa$$`):
+
+```
+PGPASSWORD="very$4f3Pa$$" pg_dump -U postgres -F c -b -v -f /home/rocky/dv_hub_db.dump dv_hub_pg
+```
+
+We can download the image to our local environment by exiting the ssh session and running:
+
+
+```
+scp -i ./mykey.key rocky@127.0.0.1:/home/rocky/dv_hub_db.dump ./
+```
+
+## Restoring the file
+
+With the postgress docker container running we can copy the file with:
+
+```
+docker cp .\dv_hub_db.dump postgres:/etc
+```
+
+And then restore with:
+
+```
+docker exec postgres pg_restore -U admin -d dv_hub_pg -v /etc/dv_hub_db.dump
+```

--- a/docs/Sphinx-guides/source/developerGuide/index.md
+++ b/docs/Sphinx-guides/source/developerGuide/index.md
@@ -1,0 +1,6 @@
+# Developer Guide
+
+**Contents**
+
+```{toctree}
+databaseDump

--- a/docs/Sphinx-guides/source/index.md
+++ b/docs/Sphinx-guides/source/index.md
@@ -1,0 +1,3 @@
+
+```{toctree}
+developerGuide/index


### PR DESCRIPTION
This pull request adds documentation to guide developers on generating and restoring database dumps, and updates the Sphinx documentation structure to include the new guide.

### New documentation for database dumps:

* [`docs/Sphinx-guides/source/developerGuide/databaseDump.md`](diffhunk://#diff-e52942c0c6054142efe36e5710f3aff6b7a865e4a55c21ed5268cde9d76b9575R1-R40): Added a detailed guide on how to generate and restore database dumps, including commands for SSH connection, database dump creation, file transfer, and restoration using Docker.

### Updates to Sphinx documentation structure:

* [`docs/Sphinx-guides/source/developerGuide/index.md`](diffhunk://#diff-6b439ce5df236388665a15dbd3598dc16998c8a7d6a9eddfee063b49a361bdffR1-R6): Created a new index file for the Developer Guide and added a table of contents linking to the database dump guide.
* [`docs/Sphinx-guides/source/index.md`](diffhunk://#diff-74979f806d9f2495c44564ce7d6c0d6cc3c8fe4c778dc0457f69123baaf976a2R1-R3): Updated the main Sphinx index to include the Developer Guide in the documentation hierarchy.